### PR TITLE
Correct metadata for being a WICG document.

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,28 +9,22 @@
     "remove"></script>
     <script class='remove'>
       var respecConfig = {
-        specStatus: "ED",
+        specStatus: "CG-DRAFT",
         edDraftURI: "https://wicg.github.io/web-share/",
+        github: {
+          repoURL: "https://github.com/WICG/web-share/",
+          branch: "master"
+        },
         shortName: "web-share",
         processVersion: 2017,
+        wg: "Web Incubator Community Group",
+        wgURI: "https://wicg.io",
         editors: [{
           name: "Matt Giuca",
           company: "Google Inc.",
           companyURL: "https://google.com"
         }],
         otherLinks: [{
-          key: 'Repository',
-          data: [{
-            value: 'Github project.',
-            href: 'https://github.com/WICG/web-share'
-          }, {
-            value: 'Issue tracker.',
-            href: 'https://github.com/WICG/web-share/issues'
-          }, {
-            value: 'Commit history.',
-            href: 'https://github.com/WICG/web-share/commits/master'
-          }]
-        }, {
           key: "Implementation status",
           data: [{
             value: "Chromium",
@@ -54,8 +48,7 @@
     </section>
     <section id="sotd">
       <p>
-        This is an early draft of the Web Share spec. The following links are
-        probably broken.
+        This is an early draft of the Web Share spec.
       </p>
     </section>
     <section class="informative">


### PR DESCRIPTION
This also uses the github key rather than manually (and differently) generating the links that including it generates.