### PR TITLE
spec: Check whether url is present before processing it.

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,21 +117,26 @@
           <ol>
             <li>Let <var>p</var> be a newly created promise.
             </li>
-            <li>Let <var>url</var> be the result of running the <a data-cite=
-            "!URL#concept-url-parser">URL parser</a> on <var>data</var>'s
-            <a for="ShareData">url</a>, with the document's <a data-cite=
-            "!HTML#document-base-url">base URL</a>, and no <var>encoding
-            override</var>.
-            </li>
-            <li>If <var>url</var> is failure, reject <var>p</var> with
-            <a data-cite=
-            "!WEBIDL#exceptiondef-typeerror"><code>TypeError</code></a>, and
-            abort these steps.
-            </li>
-            <li>Set <var>data</var> to a copy of <var>data</var>, with its
-            <a for="ShareData">url</a> field set to the result of running the
-            <a data-cite="!URL#concept-url-serializer">URL serializer</a> on
-            <var>url</var>.
+            <li>If <var>data</var>'s <a for="ShareData">url</a> member is
+            <a data-cite="!WEBIDL#dfn-present">present</a>:
+              <ol>
+                <li>Let <var>url</var> be the result of running the
+                <a data-cite="!URL#concept-url-parser">URL parser</a> on <var>
+                  data</var>'s <a for="ShareData">url</a>, with the document's
+                  <a data-cite="!HTML#document-base-url">base URL</a>, and no
+                  <var>encoding override</var>.
+                </li>
+                <li>If <var>url</var> is failure, reject <var>p</var> with
+                <a data-cite=
+                "!WEBIDL#exceptiondef-typeerror"><code>TypeError</code></a>,
+                and abort these steps.
+                </li>
+                <li>Set <var>data</var> to a copy of <var>data</var>, with its
+                <a for="ShareData">url</a> field set to the result of running
+                the <a data-cite="!URL#concept-url-serializer">URL
+                serializer</a> on <var>url</var>.
+                </li>
+              </ol>
             </li>
             <li>If the method call was not <a data-cite=
             "!HTML#triggered-by-user-activation">triggered by user


### PR DESCRIPTION
Fixes a spec bug where a non-existent URL would be parsed.

Closes #39.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/mgiuca/web-share/spec-check-missing-url.html) | [Diff](https://s3.amazonaws.com/pr-preview/WICG/web-share/0be490e...mgiuca:3386eb5.html)