### PR TITLE
spec: Changed user gesture error from SecurityError to NotAllowedError.

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,8 +149,8 @@
             activation</a>, <a data-cite=
             "!promises-guide#reject-promise">reject</a> <var>p</var> with
             <a data-cite=
-            "!WEBIDL#securityerror"><code>SecurityError</code></a>, and abort
-            these steps.
+            "!WEBIDL#notallowederror"><code>NotAllowedError</code></a>, and
+            abort these steps.
             </li>
             <li>
               <a data-cite="!HTML#in-parallel">In parallel</a>:


### PR DESCRIPTION
Minor breaking change, as discussed on #45. Closes #45.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/mgiuca/web-share/gesture-error-type.html) | [Diff](https://s3.amazonaws.com/pr-preview/WICG/web-share/5c2c8bb...mgiuca:eda2322.html)