### PR TITLE
spec: Make ShareData argument optional.

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,9 +90,19 @@
         </p>
         <pre class="idl">
           partial interface Navigator {
-            [SecureContext] Promise&lt;void&gt; share(ShareData data);
+            [SecureContext] Promise&lt;void&gt; share(optional ShareData data);
           };
         </pre>
+        <div class="note">
+          The <var>data</var> argument is marked as "optional", but it is
+          effectively required; <a for="Navigator"><code>share</code></a> will
+          throw a <a data-cite=
+          "!WEBIDL#exceptiondef-typeerror"><code>TypeError</code></a> if called
+          with no arguments. WebIDL <a data-cite=
+          "!WEBIDL#idl-operations">mandates that it be optional</a> because the
+          dictionary members are all optional. See WebIDL <a href=
+          "https://github.com/heycam/webidl/issues/130">Issue #130</a>.
+        </div>
         <p>
           User agents that do not support sharing SHOULD NOT expose <a for=
           "Navigator"><code>share</code></a> on the


### PR DESCRIPTION
This has no behavioural change, as passing an empty dictionary is a
TypeError. But it is required by the WebIDL spec.

Closes #47.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/mgiuca/web-share/optional-argument.html) | [Diff](https://s3.amazonaws.com/pr-preview/WICG/web-share/4e65307...mgiuca:f421675.html)