### PR TITLE
Working example for explainer

### DIFF
--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -45,9 +45,13 @@ To let the user share the current page's URL with an app or website of their
 choosing, just attach this JavaScript code to a "share" button.
 
 ```js
-shareButton.addEventListener('click', () => {
-  navigator.share({title: 'Example Page', url: window.location.href})
-      .then(console.log('Share successful'));
+shareButton.addEventListener("click", async () => {
+  try {
+    await navigator.share({ title: "Example Page", url: "" });
+    console.log("Share successful");
+  } catch (err) {
+    console.error("Share failed:", err.message);
+  }
 });
 ```
 


### PR DESCRIPTION
The logging in the explaioner example previously ran immediately instead
of only on success, as it wasn't placed in a callback, i.e. the
'() => {' and '}' was missing.

Also, the example previously caused an exception if the user declined
to proceed with the share.

The explainer now uses the working example from the spec.