### PR TITLE
member not field

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,7 +151,7 @@
                 <a>TypeError</a>, and abort these steps.
                 </li>
                 <li>Set <var>data</var> to a copy of <var>data</var>, with its
-                <a>url</a> field set to the result of running the
+                <a>url</a> member set to the result of running the
                   <a data-cite="!URL#concept-url-serializer">URL serializer</a>
                   on <var>url</var>.
                 </li>
@@ -252,7 +252,7 @@
           </dd>
         </dl>
         <div class="note">
-          These fields are <a data-cite=
+          These members are <a data-cite=
           "!WEBIDL#idl-USVString"><code>USVString</code></a> (as opposed to
           <a data-cite="!WEBIDL#idl-DOMString"><code>DOMString</code></a>)
           because they are not allowed to contain invalid <a data-cite=
@@ -261,7 +261,7 @@
           <a data-cite="rfc3629#section-3">UTF-8</a>).
         </div>
         <div class="note">
-          The <a>url</a> field can contain a <a data-cite=
+          The <a>url</a> member can contain a <a data-cite=
           "!URL#relative-url-with-fragment-string">relative URL</a>. In this
           case, it will be automatically resolved relative to the current page
           location, just like a <a data-cite=
@@ -287,8 +287,8 @@
         MUST have the ability to receive data that matches some or all of the
         concepts exposed in <a>ShareData</a>. To <dfn>convert data to a format
         suitable for ingestion into the target</dfn>, the user agent SHOULD map
-        the fields of <a>ShareData</a> onto equivalent concepts in the target.
-        It MAY discard fields if necessary. The meaning of each field of the
+        the members of <a>ShareData</a> onto equivalent concepts in the target.
+        It MAY discard members if necessary. The meaning of each member of the
         payload is at the discretion of the share target.
       </p>
       <p>
@@ -320,7 +320,7 @@
           the user's address book, using a specific app).
           </li>
           <li>Websites (e.g., the user agent fills in a template URL with the
-          fields of the <a>ShareData</a>, then navigates to that URL in a new
+          members of the <a>ShareData</a>, then navigates to that URL in a new
           browsing context).
           </li>
         </ul>
@@ -338,10 +338,10 @@
         <p data-link-for="ShareData">
           Mapping the <a>ShareData</a> to the share target (or operating
           system)'s native format can be tricky as some platforms will not have
-          an equivalent set of fields. For example, if the target has a "text"
-          field but not a "URL" field, one solution is to concatenate both the
-          <a>text</a> and <a>url</a> fields of <a>ShareData</a> and pass the
-          result in the "text" field of the target.
+          an equivalent set of members. For example, if the target has a "text"
+          member but not a "URL" member, one solution is to concatenate both the
+          <a>text</a> and <a>url</a> members of <a>ShareData</a> and pass the
+          result in the "text" member of the target.
         </p>
       </section>
     </section>
@@ -458,14 +458,14 @@
         <em>only</em> new members (<i>e.g.</i>, <code>navigator.share({image:
         x})</code>), it will be valid in future user agents, but a
         <a>TypeError</a> on user agents implementing an older version of the
-        spec. Developers will be asked to feature-detect any new fields they
+        spec. Developers will be asked to feature-detect any new members they
         rely on, to avoid having errors surface in their program.
       </p>
       <p>
         Editors of this spec will want to carefully consider the genericity of
-        any new members being added, avoiding fields that are closely
+        any new members being added, avoiding members that are closely
         associated with a particular service, user agent or operating system,
-        in favour of fields that can potentially be applied to a wide range of
+        in favour of members that can potentially be applied to a wide range of
         platforms and targets.
       </p>
     </section>


### PR DESCRIPTION
Consistently use the WebIDL terminology 'member' instead of sometimes
using 'member' and sometimes using 'field'.

resolves #55


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ewilligers/web-share/pull/70.html" title="Last updated on Feb 16, 2018, 4:49 AM GMT (3996335)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-share/70/f982ffb...ewilligers:3996335.html" title="Last updated on Feb 16, 2018, 4:49 AM GMT (3996335)">Diff</a>