### PR TITLE
Avoid the term "valid URL string".

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,8 +248,7 @@
             <dfn>url</dfn> member
           </dt>
           <dd>
-            A <a data-cite="!URL#valid-url-string">valid URL string</a>
-            referring to a resource being shared.
+            A URL string referring to a resource being shared.
           </dd>
         </dl>
         <div class="note">


### PR DESCRIPTION
The `url` field does *not* need to be a valid URL string (i.e., a string that when run through the URL parser, does not produce any validation error). It only needs to be a string that when run through the URL parser, does not produce failure.

There doesn't appear to be any term for this (which is kind of nuts, since this concept is literally the only thing that ever matters in any place on the web where a URL is expected). I'll just say "URL string".

(This _used to be_ a well-defined term, until whatwg/url@50cb9ab9d8 😕)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mgiuca/web-share/pull/76.html" title="Last updated on Jun 8, 2018, 6:23 AM GMT (abfb769)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-share/76/232ffba...mgiuca:abfb769.html" title="Last updated on Jun 8, 2018, 6:23 AM GMT (abfb769)">Diff</a>