### PR TITLE
Sharing files

### DIFF
--- a/level-2/index.html
+++ b/level-2/index.html
@@ -100,6 +100,7 @@
         </p>
         <pre class="idl">
           partial interface Navigator {
+            [SecureContext] boolean canShare(optional ShareData data);
             [SecureContext] Promise&lt;void&gt; share(optional ShareData data);
           };
         </pre>
@@ -125,6 +126,17 @@
         </div>
         <section>
           <h4>
+            <dfn>canShare()</dfn> method
+          </h4>
+          <p>
+            <code>canShare(</code><var>data</var><code>)</code> MUST return
+            <code>true</code> unless
+            <code>share(</code><var>data</var><code>)</code> would reject with
+            <a>TypeError</a>, in which case it MUST return <code>false</code>.
+          </p>
+        </section>
+        <section>
+          <h4>
             <dfn>share()</dfn> method
           </h4>
           <p>
@@ -136,7 +148,8 @@
             "!promises-guide#a-new-promise">a new promise</a>.
             </li>
             <li>If none of <var>data</var>'s members <a>title</a>, <a>text</a>,
-            or <a>url</a> are present, reject <var>p</var> with
+            <a>url</a> or (if the implementation supports file sharing)
+            <a>files</a> are present, reject <var>p</var> with
             <a>TypeError</a>, and abort these steps.
             </li>
             <li>If <var>data</var>'s <a>url</a> member is <a data-cite=
@@ -218,6 +231,11 @@
             kind of "always use this target in the future" option, or bypassing
             the UI if there is only a single share target.
           </div>
+          <div class="note">
+            To determine if file sharing is supported by an implementation,
+            <a>canShare()</a> can be called with a dictionary containing only
+            <code>files</code>.
+          </div>
         </section>
       </section>
       <section data-dfn-for="ShareData" data-link-for="ShareData">
@@ -229,6 +247,7 @@
             USVString title;
             USVString text;
             USVString url;
+            FileList files;
           };
         </pre>
         <p>
@@ -255,9 +274,17 @@
           <dd>
             A URL string referring to a resource being shared.
           </dd>
+          <dt>
+            <dfn>files</dfn> member
+          </dt>
+          <dd>
+            A <code><dfn data-cite=
+            "!FILE-API#filelist-section">FileList</dfn></code> referring to one
+            or more files being shared.
+          </dd>
         </dl>
         <div class="note">
-          These members are <a data-cite=
+          The string members are <a data-cite=
           "!WEBIDL#idl-USVString"><code>USVString</code></a> (as opposed to
           <a data-cite="!WEBIDL#idl-DOMString"><code>DOMString</code></a>)
           because they are not allowed to contain invalid <a data-cite=


### PR DESCRIPTION
Add a files member to Web Share dictionary.

Add canShare() so authors can determine if an implementation supports sharing a given ShareData dictionary. In particular, this allows authors to determine if an implementation supports sharing files.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ewilligers/web-share/pull/78.html" title="Last updated on Oct 10, 2018, 12:25 AM GMT (18e0eff)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-share/78/05a87d5...ewilligers:18e0eff.html" title="Last updated on Oct 10, 2018, 12:25 AM GMT (18e0eff)">Diff</a>