### PR TITLE
Use FrozenArray, not FileList

### DIFF
--- a/level-2/index.html
+++ b/level-2/index.html
@@ -248,7 +248,7 @@
             USVString title;
             USVString text;
             USVString url;
-            FileList files;
+            FrozenArray&lt;File&gt; files;
           };
         </pre>
         <p>
@@ -279,9 +279,8 @@
             <dfn>files</dfn> member
           </dt>
           <dd>
-            A <code><dfn data-cite=
-            "!FILE-API#filelist-section">FileList</dfn></code> referring to one
-            or more files being shared.
+            A <code><dfn data-cite="!FILE-API#file-section">File</dfn></code>
+            array referring to files being shared.
           </dd>
         </dl>
         <div class="note">


### PR DESCRIPTION
FileList is discouraged in new standards, and cannot be constructed
by script. We use FrozenArray of File instead.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ewilligers/web-share/pull/84.html" title="Last updated on Nov 27, 2018, 2:25 AM GMT (ca6c29f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-share/84/fb374da...ewilligers:ca6c29f.html" title="Last updated on Nov 27, 2018, 2:25 AM GMT (ca6c29f)">Diff</a>