### PR TITLE
Optional message to display when sharing

### DIFF
--- a/level-2/index.html
+++ b/level-2/index.html
@@ -101,8 +101,8 @@
         </p>
         <pre class="idl">
           partial interface Navigator {
-            [SecureContext] boolean canShare(optional ShareData data);
-            [SecureContext] Promise&lt;void&gt; share(optional ShareData data);
+            [SecureContext] boolean canShare(optional ShareData data, optional ShareOptions options);
+            [SecureContext] Promise&lt;void&gt; share(optional ShareData data, optional ShareOptions options);
           };
         </pre>
         <div class="note">
@@ -130,9 +130,10 @@
             <dfn>canShare()</dfn> method
           </h4>
           <p>
-            <code>canShare(</code><var>data</var><code>)</code> MUST return
-            <code>true</code> unless
-            <code>share(</code><var>data</var><code>)</code> would reject with
+            <code>canShare(</code><var>data</var><code>,</code>
+            <var>options</var><code>)</code> MUST return <code>true</code>
+            unless <code>share(</code><var>data</var><code>,</code>
+            <var>options</var><code>)</code> would reject with
             <a>TypeError</a>, in which case it MUST return <code>false</code>.
           </p>
         </section>
@@ -141,8 +142,8 @@
             <dfn>share()</dfn> method
           </h4>
           <p>
-            When the <a>share()</a> method is called with argument
-            <var>data</var>, run the following steps:
+            When the <a>share()</a> method is called with arguments
+            <var>data</var> and <var>options</var>, run the following steps:
           </p>
           <ol data-link-for="ShareData">
             <li>Let <var>p</var> be <a data-cite=
@@ -301,6 +302,28 @@
           "!HTML#the-a-element"><code>a</code></a> element, before being given
           to the share target.
         </div>
+      </section>
+      <section data-dfn-for="ShareOptions" data-link-for="ShareOptions">
+        <h3>
+          <code>ShareOptions</code> dictionary
+        </h3>
+        <pre class="idl">
+          dictionary ShareOptions {
+            USVString message;
+          };
+        </pre>
+        <p>
+          The <dfn>ShareOptions</dfn> dictionary currently contains one member:
+        </p>
+        <dl data-sort="">
+          <dt>
+            <dfn>message</dfn> member
+          </dt>
+          <dd>
+            A message for the user agent to display when inviting the user to
+            select a share target.
+          </dd>
+        </dl>
       </section>
     </section>
     <section data-link-for="Navigator">
@@ -470,11 +493,12 @@
       <p data-link-for="ShareData">
         The three members <a>title</a>, <a>text</a>, and <a>url</a>, are part
         of the base feature set, and implementations that provide
-        <a>navigator.share()</a> need to accept all three. Any new members that
-        are added in the future will be <em>individually
-        feature-detectable</em>, to allow for backwards-compatibility with
-        older implementations that don't recognize those members. These new
-        members might also be added as optional "MAY" requirements.
+        <a>navigator.share()</a> need to accept all three. Any new
+        <a>ShareData</a> members that are added in the future will be
+        <em>individually feature-detectable</em>, to allow for
+        backwards-compatibility with older implementations that don't recognize
+        those members. These new members might also be added as optional "MAY"
+        requirements.
       </p>
       <div class="note">
         There is <a href="https://github.com/heycam/webidl/issues/107">an open

--- a/level-2/index.html
+++ b/level-2/index.html
@@ -101,7 +101,7 @@
         </p>
         <pre class="idl">
           partial interface Navigator {
-            [SecureContext] boolean canShare(optional ShareData data, optional ShareOptions options);
+            [SecureContext] boolean canShare(optional ShareData data);
             [SecureContext] Promise&lt;void&gt; share(optional ShareData data, optional ShareOptions options);
           };
         </pre>
@@ -130,10 +130,9 @@
             <dfn>canShare()</dfn> method
           </h4>
           <p>
-            <code>canShare(</code><var>data</var><code>,</code>
-            <var>options</var><code>)</code> MUST return <code>true</code>
-            unless <code>share(</code><var>data</var><code>,</code>
-            <var>options</var><code>)</code> would reject with
+            <code>canShare(</code><var>data</var><code>)</code> MUST return
+            <code>true</code> unless
+            <code>share(</code><var>data</var><code>)</code> would reject with
             <a>TypeError</a>, in which case it MUST return <code>false</code>.
           </p>
         </section>
@@ -195,8 +194,9 @@
                 </li>
                 <li>Present the user with a choice of one or more <a>share
                 targets</a>, selected at the user agent's discretion. The user
-                MUST be given the option to cancel rather than choosing any of
-                the share targets. Wait for the user's choice.
+                agent MAY display options's message to the user. The user MUST
+                be given the latitude to cancel rather than choosing any of the
+                share targets. Wait for the user's choice.
                 </li>
                 <li>If the user chose to cancel the share operation,
                 <a data-cite="!promises-guide#reject-promise">reject</a> <var>

--- a/level-2/index.html
+++ b/level-2/index.html
@@ -194,9 +194,10 @@
                 </li>
                 <li>Present the user with a choice of one or more <a>share
                 targets</a>, selected at the user agent's discretion. The user
-                agent MAY display options's message to the user. The user MUST
-                be given the latitude to cancel rather than choosing any of the
-                share targets. Wait for the user's choice.
+                agent MAY display <var>options</var>'s <a data-link-for=
+                "ShareOptions">message</a> to the user. The user MUST be given
+                the choice to cancel rather than choosing any of the share
+                targets. Wait for the user's choice.
                 </li>
                 <li>If the user chose to cancel the share operation,
                 <a data-cite="!promises-guide#reject-promise">reject</a> <var>


### PR DESCRIPTION
For sites that wish to display a message when the
share dialog is presented, we add a new ShareOptions
dictionary.

This allows for additional options that may be needed in future,
without long method parameter lists.

Note that support for the 'message' option (and likely future
options) is not feature detectable.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ewilligers/web-share/pull/85.html" title="Last updated on Dec 21, 2018, 4:17 AM UTC (4d026ec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-share/85/d9d43d7...ewilligers:4d026ec.html" title="Last updated on Dec 21, 2018, 4:17 AM UTC (4d026ec)">Diff</a>