### PR TITLE
Don't share if files is empty, with other fields absent

### DIFF
--- a/level-2/index.html
+++ b/level-2/index.html
@@ -148,10 +148,15 @@
             <li>Let <var>p</var> be <a data-cite=
             "!promises-guide#a-new-promise">a new promise</a>.
             </li>
-            <li>If none of <var>data</var>'s members <a>title</a>, <a>text</a>,
-            <a>url</a> or (if the implementation supports file sharing)
-            <a>files</a> are present, reject <var>p</var> with
-            <a>TypeError</a>, and abort these steps.
+            <li>If none of <var>data</var>'s members <a>title</a>, <a>text</a>
+            or <a>url</a> are present:
+              <ol>
+                <li>If <var>data</var>'s member <a>files</a> is not present or
+                is empty, or if the implementation does not support file
+                sharing, reject <var>p</var> with <a>TypeError</a>, and abort
+                these steps.
+                </li>
+              </ol>
             </li>
             <li>If <var>data</var>'s <a>url</a> member is <a data-cite=
             "!WEBIDL#dfn-present">present</a>:


### PR DESCRIPTION
navigator.share({}) already rejects with TypeError.
navigator.share({files: []}) now also rejects.

This came up during implementation
https://chromium-review.googlesource.com/c/chromium/src/+/1351340/2/third_party/blink/renderer/modules/webshare/navigator_share.cc#44


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ewilligers/web-share/pull/86.html" title="Last updated on Jan 18, 2019, 2:05 AM UTC (e6cf286)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-share/86/3510c0e...ewilligers:e6cf286.html" title="Last updated on Jan 18, 2019, 2:05 AM UTC (e6cf286)">Diff</a>