### PR TITLE
Revert "Optional message to display when sharing (#85)"

### DIFF
--- a/level-2/index.html
+++ b/level-2/index.html
@@ -102,7 +102,7 @@
         <pre class="idl">
           partial interface Navigator {
             [SecureContext] boolean canShare(optional ShareData data);
-            [SecureContext] Promise&lt;void&gt; share(optional ShareData data, optional ShareOptions options);
+            [SecureContext] Promise&lt;void&gt; share(optional ShareData data);
           };
         </pre>
         <div class="note">
@@ -141,8 +141,8 @@
             <dfn>share()</dfn> method
           </h4>
           <p>
-            When the <a>share()</a> method is called with arguments
-            <var>data</var> and <var>options</var>, run the following steps:
+            When the <a>share()</a> method is called with argument
+            <var>data</var>, run the following steps:
           </p>
           <ol data-link-for="ShareData">
             <li>Let <var>p</var> be <a data-cite=
@@ -194,10 +194,8 @@
                 </li>
                 <li>Present the user with a choice of one or more <a>share
                 targets</a>, selected at the user agent's discretion. The user
-                agent MAY display <var>options</var>'s <a data-link-for=
-                "ShareOptions">message</a> to the user. The user MUST be given
-                the choice to cancel rather than choosing any of the share
-                targets. Wait for the user's choice.
+                MUST be given the option to cancel rather than choosing any of
+                the share targets. Wait for the user's choice.
                 </li>
                 <li>If the user chose to cancel the share operation,
                 <a data-cite="!promises-guide#reject-promise">reject</a> <var>
@@ -303,28 +301,6 @@
           "!HTML#the-a-element"><code>a</code></a> element, before being given
           to the share target.
         </div>
-      </section>
-      <section data-dfn-for="ShareOptions" data-link-for="ShareOptions">
-        <h3>
-          <code>ShareOptions</code> dictionary
-        </h3>
-        <pre class="idl">
-          dictionary ShareOptions {
-            USVString message;
-          };
-        </pre>
-        <p>
-          The <dfn>ShareOptions</dfn> dictionary currently contains one member:
-        </p>
-        <dl data-sort="">
-          <dt>
-            <dfn>message</dfn> member
-          </dt>
-          <dd>
-            A message for the user agent to display when inviting the user to
-            select a share target.
-          </dd>
-        </dl>
       </section>
     </section>
     <section data-link-for="Navigator">
@@ -494,12 +470,11 @@
       <p data-link-for="ShareData">
         The three members <a>title</a>, <a>text</a>, and <a>url</a>, are part
         of the base feature set, and implementations that provide
-        <a>navigator.share()</a> need to accept all three. Any new
-        <a>ShareData</a> members that are added in the future will be
-        <em>individually feature-detectable</em>, to allow for
-        backwards-compatibility with older implementations that don't recognize
-        those members. These new members might also be added as optional "MAY"
-        requirements.
+        <a>navigator.share()</a> need to accept all three. Any new members that
+        are added in the future will be <em>individually
+        feature-detectable</em>, to allow for backwards-compatibility with
+        older implementations that don't recognize those members. These new
+        members might also be added as optional "MAY" requirements.
       </p>
       <div class="note">
         There is <a href="https://github.com/heycam/webidl/issues/107">an open


### PR DESCRIPTION
This reverts commit 2edec41ee77d9562edb7c4b212d6a2618ce9a7df.

There are security concerns about showing author-supplied messages
as part of the browser UI.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ewilligers/web-share/pull/87.html" title="Last updated on Jan 15, 2019, 5:26 AM UTC (4ff8a74)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-share/87/2edec41...ewilligers:4ff8a74.html" title="Last updated on Jan 15, 2019, 5:26 AM UTC (4ff8a74)">Diff</a>