### PR TITLE
Demo now checks for https

### DIFF
--- a/demos/share-files.html
+++ b/demos/share-files.html
@@ -128,8 +128,16 @@
           testWebShareDelay);
 
       if (navigator.share === undefined) {
-        logError('Error: You need to use a browser that supports this draft ' +
-                 'proposal.');
+        if (window.location.protocol === 'http:') {
+          logError('navigator.share() is only available in secure contexts.');
+          setTimeout(() => {
+            window.location.replace(window.location.href.replace(/^http:/, 'https:'));
+          }, 4000);
+          return;
+        } else {
+          logError('Error: You need to use a browser that supports this draft ' +
+                   'proposal.');
+        }
       }
     }
 

--- a/demos/share-files.html
+++ b/demos/share-files.html
@@ -129,11 +129,8 @@
 
       if (navigator.share === undefined) {
         if (window.location.protocol === 'http:') {
-          logError('navigator.share() is only available in secure contexts.');
-          setTimeout(() => {
-            window.location.replace(window.location.href.replace(/^http:/, 'https:'));
-          }, 4000);
-          return;
+          // navigator.share() is only available in secure contexts.
+          window.location.replace(window.location.href.replace(/^http:/, 'https:'));
         } else {
           logError('Error: You need to use a browser that supports this draft ' +
                    'proposal.');

--- a/demos/share.html
+++ b/demos/share.html
@@ -115,11 +115,8 @@
 
       if (navigator.share === undefined) {
         if (window.location.protocol === 'http:') {
-          logError('navigator.share() is only available in secure contexts.');
-          setTimeout(() => {
-            window.location.replace(window.location.href.replace(/^http:/, 'https:'));
-          }, 4000);
-          return;
+          // navigator.share() is only available in secure contexts.
+          window.location.replace(window.location.href.replace(/^http:/, 'https:'));
         } else {
           logError('Error: You need to use a browser that supports this draft ' +
                    'proposal.');

--- a/demos/share.html
+++ b/demos/share.html
@@ -114,8 +114,16 @@
           testWebShareDelay);
 
       if (navigator.share === undefined) {
-        logError('Error: You need to use a browser that supports this draft ' +
-                 'proposal.');
+        if (window.location.protocol === 'http:') {
+          logError('navigator.share() is only available in secure contexts.');
+          setTimeout(() => {
+            window.location.replace(window.location.href.replace(/^http:/, 'https:'));
+          }, 4000);
+          return;
+        } else {
+          logError('Error: You need to use a browser that supports this draft ' +
+                   'proposal.');
+        }
       }
     }
 


### PR DESCRIPTION
If people arrive at the demo page via http://, we now
redirect to https instead of immediately reporting that
navigator.share is not supported.

resolves #100